### PR TITLE
Replace [::-1] step by explicit inversion function

### DIFF
--- a/src/reedsolo/reedsolo.py
+++ b/src/reedsolo/reedsolo.py
@@ -562,6 +562,7 @@ def rs_encode_msg(msg_in, nsym, fcr=0, generator=2, gen=None):
 ################### REED-SOLOMON DECODING ###################
 
 def inverted(msg):
+    '''Implements msg[::-1] explicitly to make the library compatible with MicroPython which does not support stepped slices.'''
     return list(reversed(msg))
 
 def rs_calc_syndromes(msg, nsym, fcr=0, generator=2):


### PR DESCRIPTION
This change makes the module compatible with MicroPython, which does not support stepped slices. Tested with tests/test_reedsolo.py.