### PR TITLE
Bugfix issue 71

### DIFF
--- a/tests/test_reedsolo.py
+++ b/tests/test_reedsolo.py
@@ -322,10 +322,10 @@ class TestBigReedSolomon(unittest.TestCase):
 
     def test_multiple_RSCodec(self):
         '''Test multiple RSCodec instances with different parameters'''
-        mes = 'A' * 30
-        rs_256 = RSCodec(102)
+        mes = bytes('A' * 30, 'latin1')
         rs_1024 = RSCodec(900, c_exp=10)
         bytearray(rs_1024.decode(rs_1024.encode(mes))[0])
+        rs_256 = RSCodec(102)
         rs_256.encode(mes)
         rs_1024.encode(mes)
         bytearray(rs_256.decode(rs_256.encode(mes))[0])


### PR DESCRIPTION
This is a bug fix for issue #71 .  It only applies to the case where you mix `c_exp<=8` and `c_exp>8` instances in the pure python implementation.   I also adjusted the test for multiple instances as it
 1) Didn't catch this case even though it did meet the conditions above.  
 2) Failed to convert strings to a `bytearray` when `c_exp<=8`.  This error was previously masked by issue #71 as both instances were using the customized `_bytearray`.

I'll open a new issue about the point 2 as fixing it would require a change in the behavior of the API and I feel its up to the maintainer to decide if and how they want to fix it.  