### PR TITLE
normalized input types handling for issue 86

### DIFF
--- a/src/reedsolo/reedsolo.py
+++ b/src/reedsolo/reedsolo.py
@@ -274,7 +274,7 @@ def make_bytearray(c_exp):
                 return array.array(array_type, source)
             try:
                 #double check its an array of ints (this includes bytes and numpy arrays of ints).
-                if isinstance(source[0], numbers.Integral):
+                if len(source)==0 or isinstance(source[0], numbers.Integral):
                     #note: array.array() will bufferize bytes and bytearray inputs, which will cause multiple bytes to be 
                     # packed into a single array element.  This may be what you want if c_exp = 16, but will cause errors otherwise.
                     # The user should be be responsible for packing bytes into an array.array if this is what they want.


### PR DESCRIPTION
## changes

- reworked `_bytearray` to handle input types more uniformly, and added some value checking.  `_bytearray` still defaults to a python `bytearray` for `c_exp<=8`.  But it now chooses the smallest possible array.array type.  This improves performance a little and halves the memory use for the array in cases where `8<e_exp<=16`. 
-  Also removed the global definition of `_bytearray` and initialization of globals before the call to `init_tables()`.  The former was only needed for `find_prime_polys()` when python 2.5 and earlier were used, which are not supported versions of python.  (Note: global `_bytearray` is still needed, its just not initialized until `init_tables()` is called.)
- `rs_encode_message` now only accepts array-like objects of integral types.  Its impossible to know the user's intent when given a string.
- Added a byte packing mode for `RSCodec.encode()`  when `pack=True`, `c_exp=16`, and data is given as bytes, or a string with encoding the encoder will pack two bytes per codeword.  Note odd numbers of bytes or strings that encode into an odd number of bytes cannot be packed as there is no way to pad the message out and then remove the padding without either making assumptions about the input data or including additional metadata which is not possible within a RS codeword.  
- If given an encoding, `RSCodec.decode()` will attempt to decode the given bytes back into a string.
- Added tests for string modes